### PR TITLE
fix 1-char typo in health-web.sh

### DIFF
--- a/docker_files/health-web.sh
+++ b/docker_files/health-web.sh
@@ -11,7 +11,7 @@ check_web(){
         echo "Ok: Web interface is reachable" > /root/health-web
     fi
 }
-echo 'runing check web'
+echo 'running check web'
 while true ; do
     check_web
     sleep 60


### PR DESCRIPTION
"runing" -> "running"

Found typo while reading through log file.